### PR TITLE
fix: README.mdからDBユーザ名・パスワードを削除し環境変数管理を推奨

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,16 @@ todo-app/
 - **Host**: localhost
 - **Port**: 5432
 - **Database**: todoapp
-- **Username**: todouser
-- **Password**: todopass
+
+> **セキュリティ注意**: データベースのユーザ名とパスワードは環境変数で管理してください。
+>
+> 環境変数の設定例：
+> ```bash
+> export DB_USERNAME=your_username
+> export DB_PASSWORD=your_password
+> ```
+>
+> または、`application-local.yml`ファイルを作成して設定することも可能です（このファイルは`.gitignore`に追加してください）。
 
 ### 開発用ツール
 - Spring Boot DevTools（ホットリロード）


### PR DESCRIPTION
## 概要
Issue #5 の対応として、README.mdからデータベースのユーザ名とパスワードを削除し、セキュリティを向上させました。

## 変更内容
- ✅ README.mdの119-120行目からDBユーザ名・パスワードの平文記載を削除
- ✅ 環境変数での管理方法を追記
- ✅ application-local.ymlでの設定方法も説明

## セキュリティ改善
- データベース認証情報の平文記載を削除
- 環境変数を使用した安全な管理方法を推奨
- ローカル設定ファイルでの管理方法も提供

## 関連Issue
Closes #5

## テスト
- [x] README.mdの内容確認
- [x] セキュリティ情報の削除確認
- [x] 環境変数管理方法の説明追加確認