### PR TITLE
fix: README.mdのJavaバージョンを17から21に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Spring Boot 3.5.3とMaterial Design Liteを使用したモダンなToDoアプリ
 
 ## 🛠️ 技術スタック
 
-- **Backend**: Java 17 + Spring Boot 3.5.3
+- **Backend**: Java 21 + Spring Boot 3.5.3
 - **Security**: Spring Security 6.x
 - **Database**: PostgreSQL 15+ (開発環境はDocker Compose)
 - **ORM**: Spring Data JPA
@@ -20,7 +20,7 @@ Spring Boot 3.5.3とMaterial Design Liteを使用したモダンなToDoアプリ
 ## 📦 必要な環境・依存関係
 
 ### 前提条件
-- Java 17以上
+- Java 21以上
 - Maven 3.6以上
 - Docker & Docker Compose
 


### PR DESCRIPTION
## 概要
Issue #3 の対応として、README.mdのJavaバージョン要件を正しい値に修正しました。

## 変更内容
- ✅ 技術スタック欄のJavaバージョンを「Java 17」から「Java 21」に更新
- ✅ 前提条件のJavaバージョンを「Java 17以上」から「Java 21以上」に更新

## 修正理由
- プロジェクトの実際の要件がJava 21以上であるため
- ドキュメントと実装の整合性を保つため

## 影響範囲
- ドキュメントのみの変更
- 実装コードへの影響なし

## 関連Issue
Closes #3

## テスト
- [x] README.mdの技術スタック欄の確認
- [x] README.mdの前提条件欄の確認
- [x] バージョン表記の一貫性確認